### PR TITLE
Corrected the link to the list of contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ nationality, personal appearance, race, religion, or sexual identity and orienta
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [the
-contributors](https://github.com/jagracey/Awesome-Unicode/graphs/contributors)
+contributors](https://github.com/TheJambo/awesome-testing/graphs/contributors)
 have waived all copyright and related or neighboring rights to this work. See the
 [license file](LICENSE) for details.


### PR DESCRIPTION
The list of contributors in the License section was linked to a different Awesome List.