### PR TITLE
Github action proposal: Check dead links

### DIFF
--- a/.404-links.yml
+++ b/.404-links.yml
@@ -1,0 +1,2 @@
+delay:
+    'https://github.com': 500 #Avoiding Github rate limit by delaying the request -> 500ms

--- a/.github/workflows/404-links.yml
+++ b/.github/workflows/404-links.yml
@@ -1,0 +1,14 @@
+name: Dead link checker
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check links
+      uses: restqa/404-links@2.2.0


### PR DESCRIPTION
Hello 👋,
In order to avoid to reference dead link, i want to propose to use a Github action that will check if the link share are all available online.

At the moment the GIthub action get triggered only by push event, if needed we could think of triggering it periodically.

Let me know what you think of it 😁
