### PR TITLE
Add AI & LLM Testing section with promptfoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [BeEF](http://beefproject.com/) - Manipulate the browser by exploiting any XSS vulnerabilities you find.
 - [OWASP ZAP](https://github.com/zaproxy/zaproxy) - Intercepting proxy for HTTP traffic manipulation, security scanning, and exploitation.
 
+### AI & LLM Testing
+- [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source framework for testing and red teaming LLM applications. Compare prompts, test RAG architectures, run multi-turn adversarial attacks, and catch security vulnerabilities with CI/CD integration.
+
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.
 - [DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP) - Web server using HTTP dumps as a response source for API simulation.


### PR DESCRIPTION
Adds a new **AI & LLM Testing** section to the Software category.

As LLM-powered applications become more prevalent, testing frameworks specific to AI are increasingly important. This PR adds:

- [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source framework for testing and red teaming LLM applications

**promptfoo** enables testers to:
- Compare prompts and evaluate model outputs systematically
- Test RAG architectures for accuracy and relevance
- Run multi-turn adversarial attacks to find jailbreaks and prompt injection vulnerabilities
- Integrate security testing into CI/CD pipelines

Used by 250K+ developers and featured in OpenAI Build Hours and Anthropic's courses.