### PR TITLE
Add flutter-skill to UI & End-to-End Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Courgette](https://courgette-testing.com) - Declarative BDD UI testing with Gherkin.
 - [DeviceLab](https://devicelab.dev) - Private device lab infrastructure for mobile testing. Connect your own iOS/Android devices and run Appium, Maestro, or XCUITest remotely via WebRTC. Zero-trust architecture keeps test data on your network.
 - [Ferrum](https://github.com/rubycdp/ferrum) - Chrome automation via CDP with a high-level Ruby API.
+- [flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing via MCP for Flutter, React Native, iOS, Android, Electron, Tauri, KMP, and .NET MAUI. Zero test code.
 - [Hyperbrowser](https://hyperbrowser.ai) - Scalable headless browser testing with built-in session recording.
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Open-source end-to-end testing agent.
 - [Keploy](https://keploy.io) – Open-source AI-powered end-to-end testing tool for APIs and microservices that auto-generates test cases and mocks from real traffic.


### PR DESCRIPTION
Add [flutter-skill](https://github.com/ai-dashboad/flutter-skill) — an AI-powered E2E testing tool that works via MCP. It supports Flutter, React Native, iOS, Android, Electron, Tauri, KMP, and .NET MAUI with zero test code required.

This fits well in the UI & End-to-End Testing section as it provides cross-platform E2E testing capabilities.