### PR TITLE
Add open-source Webhook Debugger to API Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Tests Coverage Tool](https://github.com/Nikita-Filonov/tests-coverage-tool) - Ultimate tool to measure gRPC service coverage from tests.
 - [Swagger Coverage Tool](https://github.com/Nikita-Filonov/swagger-coverage-tool) - The Swagger Coverage Tool is designed to measure API test coverage based on Swagger documentation. It provides automated tracking and reporting of test coverage for APIs, helping ensure that your endpoints and services are well-tested.
 - [Webhook Debugger & Logger](https://apify.com/ar27111994/webhook-debugger-logger) - Enterprise-grade tool for testing, debugging, and logging incoming webhooks in real-time.
+- [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Open-source, self-hosted webhook inspector with signature verification support.
 
 ### Security Testing
 - [BeEF](http://beefproject.com/) - Manipulate the browser by exploiting any XSS vulnerabilities you find.


### PR DESCRIPTION
## Summary

Added [Webhook Debugger](https://github.com/brancogao/webhook-debugger) to the API Testing section alongside the existing Apify tool.

## About Webhook Debugger

Webhook Debugger is an open-source, self-hosted webhook inspection tool with:

- **Real-time webhook capture** - Inspect incoming webhooks instantly
- **90-day request history** - Persistent storage for debugging
- **Signature verification** - Built-in support for Stripe, GitHub, Slack, Shopify, Twilio, SendGrid, Intercom, Telegram, Discord, and generic HMAC-SHA256
- **Self-hosted** - Deploy on Cloudflare Workers (free tier available)

## Why add this?

The existing Apify Webhook Debugger is a commercial SaaS tool. Adding an open-source, self-hosted alternative gives developers more options based on their needs (privacy, cost, customization).

## Checklist

- [x] The item is not a duplicate (complements existing Apify entry)
- [x] The description follows the existing format
- [x] The link is valid and working