### PR TITLE
Add mockd to Service Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.
 - [DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP) - Web server using HTTP dumps as a response source for API simulation.
+- [mockd](https://github.com/getmockd/mockd) - Open-source multi-protocol mock server supporting HTTP, gRPC, GraphQL, WebSocket, MQTT, and SOAP with chaos engineering and proxy recording.
 - [WireMock](https://github.com/wiremock/wiremock) - Open source HTTP mock engine written in Java. Embed in your test code, run as a standalone process, or deploy via Docker.
 
 ### Visual Testing


### PR DESCRIPTION
[mockd](https://github.com/getmockd/mockd) is a multi-protocol mock server for development and testing. Supports HTTP, gRPC, GraphQL, WebSocket, MQTT, and SOAP from a single binary. Includes chaos engineering (latency/error injection), proxy recording/replay, stateful CRUD mocking, and import from OpenAPI, Postman, WireMock, HAR, and cURL.

Apache 2.0, written in Go.