### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Requestly](https://requestly.io/) - A lightweight proxy to intercept and modify network requests.
 
 ### Accessibility & Usability Testing
+- [PageGuard](https://pageguard.org) - Free website health scanner with accessibility audit (WCAG), SEO, performance and best practices checks, plus AI-generated action plans.
 - [Colour Blindness Simulator](https://altreus.github.io/colourblind/) - Simulate different types of color blindness.
 
 ### Performance & Load Testing


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.org) is a free website health scanner that covers:
- **SEO audit** — meta tags, structured data, headings, canonicals
- **Performance** — Core Web Vitals, resource optimization
- **Accessibility** — WCAG 2.1 compliance scan
- **Best practices** — security headers, HTTPS, image optimization
- **AI-generated reports** — plain English action plans
- **REST API** — programmatic access, no signup required

## Why it fits

PageGuard is an all-in-one testing tool ideal for developers and QA engineers who want a single scan to cover multiple quality dimensions. Particularly useful in CI/CD pipelines via the REST API.

https://pageguard.org