### PR TITLE
Add Spiderhash to API Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Swagger Coverage Tool](https://github.com/Nikita-Filonov/swagger-coverage-tool) - The Swagger Coverage Tool is designed to measure API test coverage based on Swagger documentation. It provides automated tracking and reporting of test coverage for APIs, helping ensure that your endpoints and services are well-tested.
 - [Webhook Debugger & Logger](https://apify.com/ar27111994/webhook-debugger-logger) - Enterprise-grade tool for testing, debugging, and logging incoming webhooks in real-time.
 - [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Open-source, self-hosted webhook inspector with signature verification support.
+- [Spiderhash](https://spiderhash.io/) - Webhook debugging and request inspection tool for testing callback payloads, headers, and delivery behavior.
 
 ### Security Testing
 - [BeEF](http://beefproject.com/) - Manipulate the browser by exploiting any XSS vulnerabilities you find.


### PR DESCRIPTION
## Summary\n- add Spiderhash (https://spiderhash.io/) under API Testing tools\n- position it as a webhook debugging/request inspection tool\n\n## Why\nSpiderhash is directly relevant for API and webhook testing workflows, especially validating callback payloads, headers, and delivery behavior.