### PR TITLE
Add skipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### Test Management
 - [Gwirian](https://www.gwirian.com) - Open source BDD test management for QA teams. Given/When/Then scenarios, search, dashboards; self-host or hosted.
 - [Kiwi TCMS](https://github.com/kiwitcms/Kiwi) - Open-source test case management.
+- [skipper](https://github.com/get-skipper/skipper) - Real-time test execution control via Google Spreadsheet, enabling instant toggle without code changes.
 - [TestLink](https://github.com/TestLinkOpenSourceTRMS/testlink-code) - Open-source test case management system.
 - [Testomatio](https://testomat.io/) - Modern TCMS allowing sync of manual and automated tests.
 


### PR DESCRIPTION
Add [skipper](https://github.com/get-skipper/skipper) to the Test Management section.

Skipper gives teams real-time control over test execution via a shared Google Spreadsheet — enabling instant enable/disable without code changes, PRs, or deployments. Supports multiple environments and automatic test expiration.

- MIT license
- GitHub: https://github.com/get-skipper/skipper