### PR TITLE
Add Litmus to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Nuclei Scanner](https://github.com/projectdiscovery/nuclei) - nuclie is automated scanner for common vulnerbilty finding on site.
 
 ### AI & LLM Testing
+- [Litmus](https://github.com/rylinjames/litmus) - Record and replay AI agent LLM calls deterministically for testing and CI, with fault injection and reliability scoring.
 - [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source framework for testing and red teaming LLM applications. Compare prompts, test RAG architectures, run multi-turn adversarial attacks, and catch security vulnerabilities with CI/CD integration.
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 


### PR DESCRIPTION
Adding [Litmus](https://github.com/rylinjames/litmus) — an open-source Python CLI that records and replays AI agent LLM calls deterministically.

**What makes it unique:** Most LLM testing tools focus on prompt evaluation or observability. Litmus captures the full execution trace (every API call) and replays it deterministically — like VCR/cassette testing but for multi-step AI agents. It also supports fault injection (inject timeouts, errors, refusals) and reliability scoring for CI gating.

- MIT licensed, 47 tests, supports 14+ LLM providers
- Zero code changes needed — wraps any Python agent
- `pip install litmus-trace`