### PR TITLE
Add Tenro to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### AI & LLM Testing
 - [Litmus](https://github.com/rylinjames/litmus) - Record and replay AI agent LLM calls deterministically for testing and CI, with fault injection and reliability scoring.
 - [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source framework for testing and red teaming LLM applications. Compare prompts, test RAG architectures, run multi-turn adversarial attacks, and catch security vulnerabilities with CI/CD integration.
+- [Tenro](https://github.com/tenro-ai/tenro-python) - Open-source testing framework for AI agents. Simulate LLM and tool calls to test edge cases, failure paths, and agent logic without live API calls.
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 
 ### Service Virtualization


### PR DESCRIPTION
Adding [Tenro](https://github.com/tenro-ai/tenro-python) to the AI & LLM Testing section.

Simulates LLM and tool calls so you can test AI agent behavior, edge cases, and failure paths without live API calls.

https://github.com/tenro-ai/tenro-python