### PR TITLE
Add Lastest to Visual Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Fluxguard](https://fluxguard.com) - Screenshot pixel and DOM change comparisons.
 - [GoodLooks](https://github.com/dashcamio/goodlooks) - AI-powered visual validation for Playwright tests.
 - [Happo](https://happo.io) - Cross-browser screenshot and visual regression testing service, integrates with tools like Storybook, Playwright, and Cypress.
+- [Lastest](https://lastest.cloud) - Visual regression testing for Playwright with AI flake triage and baseline review.
 - [TestingBot](https://testingbot.com) - Supports automated, manual, and visual testing.
 - [recheck-web](https://github.com/retest/recheck-web) - Change comparison tool with Golden Masters and "unbreakable Selenium" tests.
 - [Sherlo](https://github.com/sherlo-io/sherlo) - Visual testing platform for React Native Storybook. Captures screenshots on iOS and Android simulators in the cloud and detects visual changes automatically.


### PR DESCRIPTION
Adds Lastest to the Visual Testing section.

- Website: https://lastest.cloud
- Source: https://github.com/las-team/lastest (MIT)
- Visual regression testing platform built on Playwright; self-hostable (docker-compose + k8s) and cloud-hosted

Placed alphabetically between Happo and TestingBot. Description ends with a period per CONTRIBUTING.