### PR TITLE
Add qa-skills to AI & LLM Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Tenro](https://github.com/tenro-ai/tenro-python) - Open-source testing framework for AI agents. Simulate LLM and tool calls to test edge cases, failure paths, and agent logic without live API calls.
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
+- - [qa-skills](https://github.com/petrkindlmann/qa-skills) – 42 QA and test-automation skills for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI). Covers Playwright, Cypress, API/unit/mobile testing, AI-augmented test generation, bug triage, accessibility, performance, CI/CD. One-line install: `npx skills add petrkindlmann/qa-skills`.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
## Adding qa-skills

Adds qa-skills to the AI & LLM Testing section — a library of 42 QA and test-automation skills for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, and any Agent Skills Standard runtime).

Why it fits: qa-skills includes AI-augmented test generation, AI bug triage, and test reliability skills, making it directly relevant to AI/LLM-assisted testing workflows.

- Repo: https://github.com/petrkindlmann/qa-skills
- - MIT licensed, actively maintained
- - One-line install: npx skills add petrkindlmann/qa-skills