### PR TITLE
Add FrontRow to Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Coursera](https://www.coursera.org/) - Online courses from top universities.
 - [Cybrary](https://www.cybrary.it/) - Online free security training.
 - [BBST Testing Courses](https://bbst.courses/bbst-testingeducation-materials/) - The famous Black Box Software Testing (BBST) courses are university level courses on Software Test Foundations, Bug Reporting and Test Design. These materials have been creative commons licensed for use by anyone. Includes articles, slides and video lectures.
+- [FrontRow](https://github.com/majdukovic/frontrow) - Open source React Native mobile app built as a hands on training surface for QA automation. Cross platform testIDs work across Maestro, Appium, Espresso and XCUITest, and a deep QA Debug Menu lets trainees force the failure modes that actually bite in production (4xx, 5xx, timeouts, offline, denied permissions, declined IAP, expired tokens) without flaky backends.
 
 ## Blogs
 - [James Bach](http://www.satisfice.com/blog/)


### PR DESCRIPTION
Hi, would like to add my open source project to the Training section.

FrontRow is an MIT licensed React Native mobile app I built specifically as a QA automation training surface. It's the kind of thing I wish had existed when I was first picking up Maestro and Appium, since every tutorial uses a TODO app and that doesn't really prepare you for the failure modes that ship to real users.

What's in it:

* Cross platform testIDs that work across Maestro, Appium, Espresso and XCUITest from one registry
* A deep QA Debug Menu so trainees can force 4xx and 5xx errors, timeouts, offline mode, denied permissions, declined IAP, expired tokens, and time travel for expiry related testing, all without a backend
* 30 Maestro flows covering auth, browse, buy, billing, and the debug menu itself
* No accounts, no secrets, runs on a simulator in five minutes

Repo: https://github.com/majdukovic/frontrow

Guidelines check:

* Searched the list, no existing entry
* One PR, one suggestion
* Description ends with a period
* No trailing whitespace
* I agree to CC0 for the list contribution per the contributing guidelines

If "Training" feels like the wrong fit, happy to move it. There isn't really a dedicated section for sample apps to practice on, which the contributing guidelines note is something you'd welcome adding, but I didn't want to introduce a whole new category for a single entry.