### PR TITLE
Add api-contract-guardian to API Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### API Testing
 - [Bruno](https://github.com/usebruno/bruno) - Open-source API client for exploring and testing APIs.
 - [API Status Check](https://apistatuscheck.com) - Real-time status monitoring dashboard for 188+ third-party APIs (OpenAI, Stripe, AWS, GitHub, etc.) with response time tracking and free alert tiers.
+- [api-contract-guardian](https://github.com/coding-dev-tools/api-contract-guardian) - Detects breaking changes in OpenAPI/REST API contracts before they reach production.
 - [Polarity](https://www.polarity.so) - The First AI QA Engineer that does full E2E, API, UI testing. Understands your entire codebase and ensures all relavent tests are conducted with our long running agent setup.
 - [BitDive](https://bitdive.io/) - Zero-code API testing platform for Java/Kotlin. Captures deep runtime context (HTTP, SQL, methods), auto-generates mocks from real traffic, and enables Live Context Replay for E2E testing and debugging.
 - [CORS Tester](https://cors-error.dev/cors-tester/) - A tool for developers and API testers to check if an API is CORS-enabled for a given domain and identify gaps.


### PR DESCRIPTION
Adds [api-contract-guardian](https://github.com/coding-dev-tools/api-contract-guardian) to the API Testing section.

api-contract-guardian detects breaking changes in OpenAPI/REST API contracts in CI before they reach production. It compares API schemas between versions and fails the build when breaking changes are detected.

This fits alongside Bruno and other API testing tools in the section. It's particularly relevant for teams practicing contract testing and API versioning.