### PR TITLE
Add apighost to Service Virtualization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.
 - [DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP) - Web server using HTTP dumps as a response source for API simulation.
+- [apighost](https://github.com/coding-dev-tools/apighost) - Generate mock API servers from OpenAPI specs for local development and testing.
 - [fakecloud](https://github.com/faiscadev/fakecloud) - Free, open-source local AWS cloud emulator for integration tests, with 23 services at 100% conformance and first-party test-assertion SDKs in 6 languages.
 - [mockd](https://github.com/getmockd/mockd) - Open-source multi-protocol mock server supporting HTTP, gRPC, GraphQL, WebSocket, MQTT, and SOAP with chaos engineering and proxy recording.
 - [WireMock](https://github.com/wiremock/wiremock) - Open source HTTP mock engine written in Java. Embed in your test code, run as a standalone process, or deploy via Docker.


### PR DESCRIPTION
Adds [apighost](https://github.com/coding-dev-tools/apighost) to the Service Virtualization section.

apighost generates mock API servers from OpenAPI specs for local development and testing. It fits alongside DeepfakeHTTP, WireMock, and other mock server tools in this section.

It helps developers and testers spin up realistic mock backends without writing any code, making it ideal for integration testing and API consumer development.