### PR TITLE
Add Pankaj Nakhat blog to Blogs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Nikita Sobolev](https://sobolevn.me/)
 - [Softwaretester Blog](https://www.softwaretester.blog/)
 - [Automation Panda](https://automationpanda.com/)
+- [Pankaj Nakhat](https://pankajnakhat.com/writing/) - QA transformation, AI-augmented testing, prompt engineering for QE, and quality engineering leadership.
 - [And others](https://github.com/ChristoWolf/awesome-testing-blogs)
 
 ## Newsletters


### PR DESCRIPTION
## Description

Adds [Pankaj Nakhat's blog](https://pankajnakhat.com/writing/) to the Blogs section.

Pankaj is a Director of Quality Engineering with 22 years of experience leading QE across 25+ product teams. The blog covers:
- QA transformation strategy and execution
- AI-augmented testing and prompt engineering for QE teams
- Quality engineering leadership and culture
- Playwright, shift-left practices, and DORA metrics

The blog has substantial long-form content on topics directly relevant to the awesome-testing audience.

## Checklist

- [x] Link is working and loads correctly
- [x] Entry follows the existing format
- [x] Content is genuinely useful to the testing community