### PR TITLE
Add Vibe AI Browser Co-Pilot — CDP multiplexer for multi-agent browser testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD-style Playwright testing.
 - [QA Wolf](https://github.com/qawolf/qawolf) - Node.js library for creating browser tests faster.
 - [UI Coverage Tool](https://github.com/Nikita-Filonov/ui-coverage-scenario-tool) - UI Coverage Tool is an innovative, no-overhead solution for tracking and visualizing UI test coverage — directly on your actual application, not static snapshots.
+- [Vibe AI Browser Co-Pilot](https://chromewebstore.google.com/detail/vibe-ai-browser-co-pilot/djodpgokbmobeclicaicnnidccoinado) - Chrome extension that multiplexes CDP connections so multiple test agents can share one real browser session simultaneously.
   
   
 ### Test Management


### PR DESCRIPTION
## What this adds

[Vibe AI Browser Co-Pilot](https://chromewebstore.google.com/detail/vibe-ai-browser-co-pilot/djodpgokbmobeclicaicnnidccoinado) — Chrome extension that multiplexes Chrome DevTools Protocol connections, enabling multiple simultaneous AI agents (claude-code, playwright-mcp, browser-use) to share one real Chrome session without session ownership conflicts.

## Why it belongs here

The list already covers CDP-based browser testing tools (Ferrum, chrome-devtools-mcp). This adds a layer that solves a common pain point for teams running parallel or multi-agent test pipelines: the "browser already in use" conflict when more than one tool tries to own the CDP session simultaneously. It is a browser testing infrastructure tool, not a test framework.

## Checklist

- [x] Single suggestion per PR
- [x] Description is short and ends with a period
- [x] No duplicates — searched existing entries, none cover CDP multiplexing
- [x] Link is to the Chrome Web Store listing (canonical install URL)