### PR TITLE
Add silentdrop-llm to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
+- [silentdrop-llm](https://github.com/sravan27/silentdrop-llm) - Zero-dependency runtime guard for the silent failure modes of LLM/agent responses (missing required fields, enum drift, hallucinated IDs, claim/list mismatches). `npm i silentdrop-llm`.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
Adds **silentdrop-llm** under the **AI & LLM Testing** section.

silentdrop-llm is a zero-dependency (MIT) npm package: a runtime guard that catches the silent failure modes of LLM/agent responses — the ones JSON.parse + a basic schema validator won't catch.

- Missing required fields the model quietly omitted (`null` / `""` slipping through)
- Enum drift (`"in-progress"` when the schema says `"in_progress"`)
- Hallucinated IDs (response references a deal/lead/user ID not in the lookup context)
- Claim-vs-list mismatch (response says `total: 5` but the returned array is empty)

Drop it between a model response and any side-effecting use of that response so wrong outputs fail loudly instead of corrupting downstream state. 7/7 unit tests, runnable demo against synthetic responses.

- Repo: https://github.com/sravan27/silentdrop-llm
- npm: https://www.npmjs.com/package/silentdrop-llm

Happy to adjust wording or placement if you'd prefer a different home for it.