### PR TITLE
feat: add TWZRD Agent Intel to AI & LLM Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agents on Solana. Verify agent wallet identity before x402 micropayments and paid API calls. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **AI & LLM Testing** section.

TWZRD Agent Intel provides on-chain trust scoring for AI agents on Solana, enabling teams to verify agent wallet identity before making x402 micropayments or granting access to paid test execution APIs. This fits alongside the existing AI agent testing tools in the section.

**Free MCP integration:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Tools exposed:**
- `score_agent` — trust score for a Solana agent wallet
- `preflight_check` — pre-payment identity check (free)
- `get_trust_receipt` — signed trust receipt (x402 paid)

Useful for QA teams running AI test agents with access to paid APIs or cloud test grid access via x402.