### PR TITLE
Add MockServer to Service Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [DeepfakeHTTP](https://github.com/xnbox/DeepfakeHTTP) - Web server using HTTP dumps as a response source for API simulation.
 - [fakecloud](https://github.com/faiscadev/fakecloud) - Free, open-source local AWS cloud emulator for integration tests, with 23 services at 100% conformance and first-party test-assertion SDKs in 6 languages.
 - [mockd](https://github.com/getmockd/mockd) - Open-source multi-protocol mock server supporting HTTP, gRPC, GraphQL, WebSocket, MQTT, and SOAP with chaos engineering and proxy recording.
+- [MockServer](https://github.com/mock-server/mockserver-monorepo) - Mocking, debugging proxy and chaos engineering tool for multiple protocols (HTTP, gRPC, GraphQL, LLM, MCP, Kafka, TCP and more); mock any dependency, record/replay and inspect traffic, verify requests, and inject faults. Docker, JAR, Helm, multi-language clients.
 - [WireMock](https://github.com/wiremock/wiremock) - Open source HTTP mock engine written in Java. Embed in your test code, run as a standalone process, or deploy via Docker.
 - [ApiNotes](https://apinotes.io/mock-server) - Drop your OpenAPI spec and get a fully functional mock API server instantly. Export to Bruno API client or test directly.
 


### PR DESCRIPTION
Adds [MockServer](https://www.mock-server.com) to the **Service Virtualization** section.

MockServer is an open-source (Apache-2.0) HTTP(S)/REST/gRPC/LLM mock server and proxy used for integration and chaos testing — mock any dependency, record/replay traffic, verify requests, and inject faults. It runs as a Docker image, JAR, Helm chart, or embedded Java library, with clients for many languages.

- Source: https://github.com/mock-server/mockserver-monorepo
- Homepage/docs: https://www.mock-server.com

Checklist:
- [x] One item added, in the relevant section
- [x] Inserted in alphabetical order
- [x] Follows the list's entry format
- [x] Project is open-source and actively maintained