### PR TITLE
Add podium-mcp - Unified mobile E2E testing MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [DeviceLab](https://devicelab.dev) - Private device lab infrastructure for mobile testing. Connect your own iOS/Android devices and run Appium, Maestro, or XCUITest remotely via WebRTC. Zero-trust architecture keeps test data on your network.
 - [Ferrum](https://github.com/rubycdp/ferrum) - Chrome automation via CDP with a high-level Ruby API.
 - [flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing via MCP for Flutter, React Native, iOS, Android, Electron, Tauri, KMP, and .NET MAUI. Zero test code.
+- [podium-mcp](https://github.com/hoainho/podium-mcp) - Unified mobile E2E testing MCP server — iOS simulator control, native UI automation, Maestro flows, React Native debugging, and WebView DOM inspection.
 - [Hyperbrowser](https://hyperbrowser.ai) - Scalable headless browser testing with built-in session recording.
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Open-source end-to-end testing agent.
 - [Keploy](https://keploy.io) – Open-source AI-powered end-to-end testing tool for APIs and microservices that auto-generates test cases and mocks from real traffic.


### PR DESCRIPTION
## Description

Adds [podium-mcp](https://github.com/hoainho/podium-mcp) to the UI & End-to-End Testing section alongside other MCP-based testing tools — a unified mobile E2E testing MCP server providing iOS simulator control, native UI automation, Maestro flows, React Native debugging, and WebView DOM inspection.

## Checklist

- [x] Search previous suggestions before making a new one (no duplicates)
- [x] Description ends with a period
- [x] Spelling and grammar checked