### PR TITLE
Add postman2pytest to API Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Open-source, self-hosted webhook inspector with signature verification support.
 - [Spiderhash](https://spiderhash.io/) - Webhook debugging and request inspection tool for testing callback payloads, headers, and delivery behavior.
 - [KushoAI](https://kusho.ai/) - AI-native platform for API contract testing, end-to-end testing, UI testing, and continuous security scanning, with self-healing tests that automatically adapt to code changes in CI/CD.
+- [postman2pytest](https://github.com/golikovichev/postman2pytest) - Convert a Postman Collection v2.1 JSON file into a ready-to-run pytest test suite.
 
 ### Security Testing
 - [BeEF](http://beefproject.com/) - Manipulate the browser by exploiting any XSS vulnerabilities you find.


### PR DESCRIPTION
Adds [postman2pytest](https://github.com/golikovichev/postman2pytest) to the API Testing section.

It converts a Postman Collection v2.1 JSON file into a ready-to-run pytest test suite, which fills a gap for teams moving from Postman into Python-based CI.

- Open source (MIT), published on PyPI
- One-line entry, description ends with a period
- Single suggestion per the contribution guidelines