### PR TITLE
Add Parlel to Service Virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [fakecloud](https://github.com/faiscadev/fakecloud) - Free, open-source local AWS cloud emulator for integration tests, with 23 services at 100% conformance and first-party test-assertion SDKs in 6 languages.
 - [mockd](https://github.com/getmockd/mockd) - Open-source multi-protocol mock server supporting HTTP, gRPC, GraphQL, WebSocket, MQTT, and SOAP with chaos engineering and proxy recording.
 - [MockServer](https://github.com/mock-server/mockserver-monorepo) - Mocking, debugging proxy and chaos engineering tool for multiple protocols (HTTP, gRPC, GraphQL, LLM, MCP, Kafka, TCP and more); mock any dependency, record/replay and inspect traffic, verify requests, and inject faults. Docker, JAR, Helm, multi-language clients.
+- [Parlel](https://github.com/dksingh1997/parlel) - Open-source set of 250+ service emulators (Stripe, Postgres, Slack, S3, Kafka and more) on local Docker, speaking real wire protocols so unmodified client libraries connect to localhost.
 - [WireMock](https://github.com/wiremock/wiremock) - Open source HTTP mock engine written in Java. Embed in your test code, run as a standalone process, or deploy via Docker.
 - [ApiNotes](https://apinotes.io/mock-server) - Drop your OpenAPI spec and get a fully functional mock API server instantly. Export to Bruno API client or test directly.
 


### PR DESCRIPTION
Adds [Parlel](https://github.com/dksingh1997/parlel) to the Service Virtualization section.

Parlel is an open-source (MIT) set of 250+ service emulators you run locally on Docker — Stripe, Postgres, Slack, S3, Kafka and more — speaking the real wire protocols, so unmodified client libraries (psycopg, stripe-node, kafkajs, …) connect to localhost. Useful for integration tests and CI without hitting real services.

Guidelines:
- [x] Individual PR for a single suggestion.
- [x] Searched existing entries (not a duplicate).
- [x] Description is short and ends with a period.
- [x] Placed alphabetically in Service Virtualization.