### PR TITLE
Add selfsame to AI testing tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
+- [selfsame](https://github.com/PraveenKPandu/Selfsame) - Sound refactor verifier: captures real inputs from your tests, replays old vs new, and refuses when it can't compare safely.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
Added selfsame to the list of AI testing tools in the README.

Brief description of the project. Automated characterization testing with a soundness guarantee. It captures the real arguments your existing test suite already feeds your functions (no hand-written golden snapshots), replays two versions in isolated subprocesses, and compares behavior structurally. The distinguishing property is zero false confidence: unlike golden-master/snapshot tests, it refuses (unverifiable) on uncontrolled I/O, threads, or nondeterminism rather than blessing a flaky or wrong result. Pure standard library (no runtime deps), Python 3.8+, and measured on real OSS repos, 86–100% sound auto-verify, with "confidently wrong" verdicts driven to 0% on a stratified corpus. Solves a niche that matters more in the AI-coding era, and answer "did this refactor change behavior?" elegantly and without maintenance.