### PR TITLE
Add Testward to UI & End-to-End Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Open-source end-to-end testing agent.
 - [Keploy](https://keploy.io) – Open-source AI-powered end-to-end testing tool for APIs and microservices that auto-generates test cases and mocks from real traffic.
 - [TestMu AI (formerly LambdaTest)](https://www.testmuai.com) - Full-Stack Agentic AI Quality Engineering platform that empowers teams to test intelligently and ship faster.
+- [Testward](https://testward.app) - GitHub App that flags which Playwright/Cypress/Selenium specs a PR will break — at review time, even when the tests live in a separate repo.
 - [Mocky Balboa](https://docs.mockybalboa.com/) - Mock server side network requests in your fullstack apps declaratively at runtime
 - [Octomind](https://github.com/OctoMind-dev) - AI-powered test case discovery and maintenance.
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD-style Playwright testing.


### PR DESCRIPTION
Adding [Testward](https://testward.app) — a GitHub App that reads each pull request and flags which Playwright/Cypress/Selenium specs the change will break, at review time, including when the automation lives in a separate repo from the app.

Disclosure: I'm the author. It fits the UI & End-to-End Testing section alongside the other PR-time/E2E tooling there. Free on public repos. Entry follows the list's format.

There's also a no-install demo of the diff-analysis at https://testward.app/diff-scanner if you want to evaluate quickly.