### PR TITLE
Add Specmatic to API Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [HttpMaster](https://www.httpmaster.net) - Professional software tool for HTTP testing and debugging.
 - [Keploy](https://github.com/keploy/keploy) - API Testing Platform that automatically generates unit test cases along with dependency mocks.
 - [RestQA](https://github.com/restqa/restqa) - REST API testing framework based on Gherkin.
+- [Specmatic](https://specmatic.io) - Open-source contract-driven development tool that turns API specifications (OpenAPI, AsyncAPI, gRPC) into executable contract tests and intelligent service virtualizations, enabling independent microservice development and testing without integration environments.
 - [SpecTest](https://github.com/justiceo/spectest) - Truly declarative API testing framework in Js, or plain JSON.
 - [Tests Coverage Tool](https://github.com/Nikita-Filonov/tests-coverage-tool) - Ultimate tool to measure gRPC service coverage from tests.
 - [Swagger Coverage Tool](https://github.com/Nikita-Filonov/swagger-coverage-tool) - The Swagger Coverage Tool is designed to measure API test coverage based on Swagger documentation. It provides automated tracking and reporting of test coverage for APIs, helping ensure that your endpoints and services are well-tested.


### PR DESCRIPTION
Adding [Specmatic](https://specmatic.io) to the API Testing subsection.

Specmatic is an open-source tool that converts OpenAPI specs into executable contract tests and auto-generated mocks, so teams can test APIs independently without integration environments. MIT licensed and actively maintained.

- GitHub: https://github.com/specmatic/specmatic
- Website: https://specmatic.io
