### PR TITLE
Add naughty-datetimes to Test Data Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 
 ### Test Data Management
 - [MockHero](https://mockhero.dev) - REST API for generating synthetic test data. 156 field types, 22 locales, relational data, sub-50ms. Free tier available.
+- [naughty-datetimes](https://github.com/FoundagentTest/naughty-datetimes) - Categorized, annotated corpus of date and time values that break parsers, storage, and formatting, as drop-in JSON and text fixtures.
 - [Synth](https://github.com/getsynth/synth) - Open-source test data generator.
 - [Touca](https://github.com/trytouca/trytouca) - Continuous regression testing for behavioral and performance comparisons.
 - [test-each](https://github.com/ehmicky/test-each) - Data-driven testing framework.


### PR DESCRIPTION
Adds [naughty-datetimes](https://github.com/FoundagentTest/naughty-datetimes) under **Test Data Management**.

It's a ready-to-use, CC0 corpus of date/time values that commonly break parsers, storage, and formatting (DST gaps, Feb 29 in non-leap centuries, 2038 overflow, leap seconds, `-00:00`, `24:00:00`, five-digit years, etc.). Unlike a plain word list, every fixture is annotated with *why it breaks* and *what correct handling looks like*, and it's organized by category — provided as both `fixtures/datetimes.json` and a flat `.txt` for drop-in fuzzing. It complements big-list-of-naughty-strings for the datetime domain, so it's useful test data for anyone hardening time handling.

- One item, one section (Test Data Management), description ends with a period.
- Public-domain (CC0), consistent with this list's contribution terms.