### PR TITLE
Add BrowserBash to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
+- [BrowserBash](https://github.com/PramodDutta/browserbash) - Open-source CLI where an AI agent runs plain-English browser tests in a real Chrome and returns deterministic verdicts (assertions, exit codes). Ships an MCP server so coding agents can validate their own UI work. Free local models, no API keys.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
Adds **BrowserBash** to the AI & LLM Testing section, beside Evaliphy.

- Repo: https://github.com/PramodDutta/browserbash (Apache-2.0)
- npm: `browserbash-cli` (also on the official MCP Registry)

BrowserBash is an open-source CLI where an AI agent runs plain-English browser tests in a real Chrome and returns deterministic verdicts (real Playwright assertions, CI exit codes). It ships an MCP server so coding agents (Claude Code, Cursor) can validate their own UI changes. Runs on free local Ollama models, no API keys. Single-line addition matching the section format.