### PR TITLE
Add QASkills.sh to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
+- [QASkills.sh](https://qaskills.sh) - Open registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the qaskills CLI. Works with Claude Code, Cursor, and 30+ other agents.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
Adds [QASkills.sh](https://qaskills.sh) to the **AI & LLM Testing** section.

QASkills.sh is an open, MIT-licensed registry of 400+ QA and testing skills (Playwright E2E, API testing, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the `qaskills` CLI. It works with Claude Code, Cursor, and 30+ other agents.

- Site: https://qaskills.sh
- Source: https://github.com/PramodDutta/qaskills

Single-line addition matching the section's entry format.