### PR TITLE
Add Tura Benchmark to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### AI & LLM Testing
 - [promptfoo](https://github.com/promptfoo/promptfoo) - Open-source framework for testing and red teaming LLM applications. Compare prompts, test RAG architectures, run multi-turn adversarial attacks, and catch security vulnerabilities with CI/CD integration.
 - [Tenro](https://github.com/tenro-ai/tenro-python) - Open-source testing framework for AI agents. Simulate LLM and tool calls to test edge cases, failure paths, and agent logic without live API calls.
+- [Tura Benchmark](https://github.com/Tura-AI/benchmark) - Public long-horizon coding-agent benchmark with archived prompts, per-round tool calls, token usage, patches, and verifier results.
 - [voicetest](https://github.com/voicetestdev/voicetest) - Open-source test harness for voice AI agents supporting Retell, VAPI, LiveKit, and Bland with autonomous simulations and LLM-based evaluation.
 - [AgentSkeptic](https://github.com/jwekavanagh/agentskeptic) - Verifies AI/agent workflows by checking database state after execution, comparing expected vs observed outcomes with read-only SQL.
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.


### PR DESCRIPTION
## Summary

- add Tura Benchmark to the **AI & LLM Testing** section
- link to the public benchmark repository with archived prompts, per-round tool calls, token usage, patches, and verifier results

## Why

This gives software testers a public long-horizon coding-agent evaluation resource whose underlying run artifacts can be inspected and reproduced.

## Checks

- confirmed there is no existing Tura entry, pull request, or issue
- kept the description short and ended it with a period, per the contribution guide
- changed one README line only

**Disclosure:** I am a maintainer of Tura and the linked benchmark repository.