### PR TITLE
Add Tessera to Visual Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [GoodLooks](https://github.com/dashcamio/goodlooks) - AI-powered visual validation for Playwright tests.
 - [Happo](https://happo.io) - Cross-browser screenshot and visual regression testing service, integrates with tools like Storybook, Playwright, and Cypress.
 - [Lastest](https://lastest.cloud) - Visual regression testing for Playwright with AI flake triage and baseline review.
+- [Tessera](https://app.tesserae.site) - Renders a page on many real device viewports at once for responsive checks. Live browser tiles with synced scrolling and DPR-accurate screenshot export.
 - [TestingBot](https://testingbot.com) - Supports automated, manual, and visual testing.
 - [recheck-web](https://github.com/retest/recheck-web) - Change comparison tool with Golden Masters and "unbreakable Selenium" tests.
 - [Sherlo](https://github.com/sherlo-io/sherlo) - Visual testing platform for React Native Storybook. Captures screenshots on iOS and Android simulators in the cloud and detects visual changes automatically.


### PR DESCRIPTION
Adding [Tessera ](https://app.tesserae.site/)to the Visual Testing section.

It's for responsive checks rather than pixel regression. You get a canvas where the same page renders on lots of real device viewports at the same time, as live interactive browser sessions. Scrolling can sync across tiles, and you can export DPR-accurate screenshots of the whole set. There's a free tier and the demo works without an account.

Matched the list format.