### PR TITLE
Add hotato (voice-agent regression testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
 - [QASkills.sh](https://qaskills.sh) - Open registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the qaskills CLI. Works with Claude Code, Cursor, and 30+ other agents.
 - [nika](https://github.com/supernovae-st/nika) - Workflow engine for AI with testing built in: `nika test` pins a workflow's offline behavior as a golden snapshot (deterministic mock provider, zero keys) and replays it in CI; every run also leaves a hash-chained trace for post-hoc verification.
+- [hotato](https://github.com/attenlabs/hotato) - Regression testing for voice agents: scores turn timing from a call recording and checks what the agent said against what the backend did, then gates CI on the exit code.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
hotato scores turn timing from a two-channel call recording, checks what the agent said against what the backend did, and gates CI on the exit code. MIT, on PyPI.

Disclosure: maker submission.