### PR TITLE
Add rrweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ### Screen Recording & Session Replays
 - [Captura](https://github.com/MathewSachin/Captura) - Open-source video recording tool.
 - [PR Preview](https://www.pr-preview.com/) - MCP for Claude Code that drives your web app in a headed browser and records before/after demo videos of a pull request as MP4 or GIF.
+- [rrweb](https://github.com/rrweb-io/rrweb) - Records the DOM and user interactions as a typed JSON event stream and replays them pixel-perfect.
 
 ### Mind Mapping & Documentation
 - [Xmind](http://www.xmind.net/) - Mind mapping tool for documenting test cases and strategies.


### PR DESCRIPTION
Adds rrweb under Screen Recording & Session Replays.

rrweb is an open-source library that records the DOM and user interactions in the browser and replays them. Testers use it to capture reproducible bug reports and review real user sessions. I searched open and closed PRs and found no prior rrweb suggestion.

- Repo: https://github.com/rrweb-io/rrweb (19,899 stars, MIT)
- Docs: https://rrweb.com/docs/

Disclosure: I work on rrweb.
