### PR TITLE
Add Kane CLI to UI & End-to-End Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [TestingBot](https://testingbot.com) - Supports automated, manual, and visual testing.
 - [recheck-web](https://github.com/retest/recheck-web) - Change comparison tool with Golden Masters and "unbreakable Selenium" tests.
 - [wopee.io](https://wopee.io/) - Autonomous visual regression testing platform.
-- [Lambda testing Tool](https://www.testmu.ai/lt-browser)- UI Testing Frawnework. 
+- [SmartUI by TestMu AI (formerly LambdaTest)](https://www.testmuai.com/visual-testing-tool/)- AI-Native Visual Testing Tool for Flawless UIs across browsers, apps, websites, and PDFs.
 
 ### UI & End-to-End Testing
 - [BugBug](https://bugbug.io) - No-code test automation tool for web applications.
@@ -69,7 +69,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Hyperbrowser](https://hyperbrowser.ai) - Scalable headless browser testing with built-in session recording.
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Open-source end-to-end testing agent.
 - [Keploy](https://keploy.io) – Open-source AI-powered end-to-end testing tool for APIs and microservices that auto-generates test cases and mocks from real traffic.
-- [LambdaTest](https://www.lambdatest.com) - Unified enterprise test execution cloud platform for browser and mobile testing.
+- [TestMu AI (formerly LambdaTest)](https://www.testmuai.com) - Full-Stack Agentic AI Quality Engineering platform that empowers teams to test intelligently and ship faster.
 - [Mocky Balboa](https://docs.mockybalboa.com/) - Mock server side network requests in your fullstack apps declaratively at runtime
 - [Octomind](https://github.com/OctoMind-dev) - AI-powered test case discovery and maintenance.
 - [playwright-bdd](https://github.com/vitalets/playwright-bdd) - BDD-style Playwright testing.
@@ -155,7 +155,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Automation Panda](https://automationpanda.com/)
 
 ## Newsletters
-- [Coding Jag](https://www.lambdatest.com/newsletter) - Your weekly dose of the latest in Testing, Development, CI/CD, and Automation—keeping you ahead of the curve."
+- [Coding Jag](https://www.testmuai.com/newsletter) - Your weekly dose of the latest in AI, Testing, Development, CI/CD, and Automation—keeping you ahead of the curve.
 - [Software Testing Weekly](https://softwaretestingweekly.com/) - A curated round-up of the best software testing news and tools published every Friday.
 
 ## Suggested Awesome Lists

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Ferrum](https://github.com/rubycdp/ferrum) - Chrome automation via CDP with a high-level Ruby API.
 - [Hyperbrowser](https://hyperbrowser.ai) - Scalable headless browser testing with built-in session recording.
 - [Hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Open-source end-to-end testing agent.
+- [Kane CLI](https://www.testmuai.com/kane-cli/) - Natural-language browser testing from the terminal, locally or in CI, with export to Playwright and shareable run evidence.
 - [Keploy](https://keploy.io) – Open-source AI-powered end-to-end testing tool for APIs and microservices that auto-generates test cases and mocks from real traffic.
 - [TestMu AI (formerly LambdaTest)](https://www.testmuai.com) - Full-Stack Agentic AI Quality Engineering platform that empowers teams to test intelligently and ship faster.
 - [Mocky Balboa](https://docs.mockybalboa.com/) - Mock server side network requests in your fullstack apps declaratively at runtime


### PR DESCRIPTION
Adds [Kane CLI](https://www.testmuai.com/kane-cli/) to UI & End-to-End Testing, placed alphabetically. It's a terminal tool for running browser tests written as natural-language objectives, locally or in CI, with export to Playwright and a shareable evidence link per run. Being upfront on two counts: I work on Kane CLI at TestMu AI, and TestMu AI already has a platform entry in this section — Kane CLI is a separate standalone tool, but if you'd rather keep one entry per vendor I understand. Reachable at sparshk@testmuai.com.