### PR TITLE
Add whatbroke to AI & LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
 - [QASkills.sh](https://qaskills.sh) - Open registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the qaskills CLI. Works with Claude Code, Cursor, and 30+ other agents.
 - [nika](https://github.com/supernovae-st/nika) - Workflow engine for AI with testing built in: `nika test` pins a workflow's offline behavior as a golden snapshot (deterministic mock provider, zero keys) and replays it in CI; every run also leaves a hash-chained trace for post-hoc verification.
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff your AI agent's behavior between two runs: tool calls, args, cost, latency, and outcome flips. Flake detection for non-deterministic agents and exit codes for CI.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
Adds whatbroke, a CLI that diffs an AI agent's behavior between two runs so you can see what actually changed after a prompt or model swap: tool calls, args, cost, latency, outcome flips. It puts a rate on flaky findings when you record multiple samples per scenario. MIT, TypeScript, on npm as whatbroke-cli. Placed at the bottom of the AI & LLM Testing section, description ends with a full stop per the guidelines.