### PR TITLE
Add StructEval to AI and LLM testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
 - [QASkills.sh](https://qaskills.sh) - Open registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the qaskills CLI. Works with Claude Code, Cursor, and 30+ other agents.
 - [nika](https://github.com/supernovae-st/nika) - Workflow engine for AI with testing built in: `nika test` pins a workflow's offline behavior as a golden snapshot (deterministic mock provider, zero keys) and replays it in CI; every run also leaves a hash-chained trace for post-hoc verification.
+- [StructEval](https://github.com/TIGER-AI-Lab/StructEval) - Benchmark and evaluation framework for testing language models on structured-output generation and conversion.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
## What

Add StructEval to the AI & LLM Testing section.

## Why

StructEval is a TMLR 2025 benchmark and evaluation framework for testing language models on structured-output generation and conversion, making it a focused testing resource for this category.

## Impact

This adds one README entry and does not change code or dependencies.

## Checks

- Searched the README, issues, and pull requests for duplicate StructEval entries.
- Confirmed the StructEval repository link resolves.
- Ran `git diff --check`.

I am a StructEval maintainer and am submitting this entry in that capacity. This contribution was prepared with assistance from OpenAI Codex and manually reviewed before submission.
