### PR TITLE
Add flakelens

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [QALadder](https://qaladder.org) - A free, sequenced roadmap from manual QA to SDET, with a 150-question interview bank, browser-based practice labs, and QA tools.
 
 ## Others
+- [flakelens](https://github.com/nabsei/flakelens) - Finds flaky (not broken) CI jobs from the GitHub Actions history a repo already has, no rerun or config required.
 - [Testers Rage Playlist](https://play.spotify.com/user/sanchezni/playlist/5yzT0HrymwEeO8ckqgkPiW) - A collaborative playlist from testers for when the red mist descends.
 - [Software Testing Conferences](http://testingconferences.org/) - A list of software testing conferences and workshops.
 - [Software Testing Interview Tool](https://github.com/TheJambo/ToDoInterviewTest) - A very buggy To Do List to facilitate face to face interviews.


### PR DESCRIPTION
## What

Adds [flakelens](https://github.com/nabsei/flakelens) to the Others section.

## Why

flakelens finds flaky (not just broken) CI jobs from the GitHub Actions
history a repo already has: no rerun, no test-report artifact, no config.
It flags jobs that fail in isolation (while sibling jobs in the same run
pass) repeatedly across unrelated commits — the signature of
non-deterministic tests rather than a genuinely broken build. It doesn't
fit the existing categories (not a framework, not a management/data tool),
so I placed it under Others, alphabetically before the existing entry.

## Checklist

- [x] Single addition, alphabetical order within its section.
- [x] Description is concise and ends with a period.
- [x] Link points to the project's own repository.

---
Disclosure: this PR was prepared with the assistance of Claude Code
(Anthropic). The addition and description above were reviewed and
confirmed by me before submitting.