### PR TITLE
Add sms-florin to Test Data Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 
 ### Test Data Management
 - [Temp Mail 24](https://temp-mail24.com/) - Browser-based receive-only temporary inbox for permitted manual signup-flow testing.
+- [sms-florin](https://flo-voice1.com) - Rent a real UK phone number to receive SMS/OTP codes for testing verification flows (WhatsApp, Telegram, Google, and others). Ships a JS/TS SDK for CI/QA automation.
 - [DATAMIMIC CE](https://github.com/rapiddweller/datamimic) - Open-source, deterministic engine for model-driven synthetic test data and PII pseudonymization. Pin a seed and get byte-identical output with a provenance hash on every run. Python, MIT.
 - [JSON Validation Test Cases](https://github.com/UtilHatch/json-validation-test-cases) - Reusable valid, invalid, and edge-case JSON fixtures for testing parsers, validators, APIs, editors, and error handling.
 - [MockJutsu](https://github.com/altansayan/mock-jutsu-api) - Algorithmic open-source mock data engine generating 390+ format-valid types (IBAN, TCKN, Luhn, VIN, NHS, SWIFT, MRZ and more). CLI + REST API + Python package + JMeter


### PR DESCRIPTION
Adding [sms-florin](https://flo-voice1.com) next to Temp Mail 24, since it serves the same "receive-only test fixture" purpose for phone/SMS instead of email.

- Rents real UK phone numbers (own GOIP hardware, real SIM cards on EE/Three networks, not a reseller API) so testers can receive SMS/OTP codes for verification-flow testing (WhatsApp, Telegram, Google, and others) without exposing a personal number.
- Ships a public REST API and a JS/TS SDK (`npm install sms-florin`) aimed specifically at CI/QA automation, with a `waitForSms()` helper for polling in tests.

Happy to adjust the description or placement if there's a better fit.