### PR TITLE
Add Image Diff to Visual Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Fluxguard](https://fluxguard.com) - Screenshot pixel and DOM change comparisons.
 - [GoodLooks](https://github.com/dashcamio/goodlooks) - AI-powered visual validation for Playwright tests.
 - [Happo](https://happo.io) - Cross-browser screenshot and visual regression testing service, integrates with tools like Storybook, Playwright, and Cypress.
+- [Image Diff](https://nutilz.com/image-diff) - Free, browser-based pixel diff tool for comparing two images and highlighting exactly what changed, with an adjustable sensitivity threshold. No upload, no sign-up.
 - [Lastest](https://lastest.cloud) - Visual regression testing for Playwright with AI flake triage and baseline review.
 - [TestingBot](https://testingbot.com) - Supports automated, manual, and visual testing.
 - [recheck-web](https://github.com/retest/recheck-web) - Change comparison tool with Golden Masters and "unbreakable Selenium" tests.


### PR DESCRIPTION
Adds [Image Diff](https://nutilz.com/image-diff), a free browser-based tool for comparing two images pixel-by-pixel and highlighting the differences. Runs entirely client-side via the Canvas API (no upload, no sign-up), with an adjustable sensitivity threshold and a downloadable diff image. Useful as a lightweight companion to the section's existing screenshot/visual-regression tools for quick manual before/after checks.