### PR TITLE
Add QAPractices to QA and testing road map

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Selenium](https://github.com/christian-bromann/awesome-selenium) - Better than searching Google if you know what you want.
 - [Security](https://github.com/sbilly/awesome-security) - This is mostly focused on Infrastructure, but if you're testing a series of systems, this is very useful.
 - [Awesome Software Quality](https://github.com/ligurio/awesome-software-quality) - A list of free software testing and verification resources.
+- [QAPractices](https://qapractices.com/) - Curated free QA resource hub with test cases, checklists, templates and guides for API, web, mobile, security, accessibility and performance testing.
 - [Awesome AI Testing](https://github.com/tugkanboz/awesome-ai-testing) - A curated list of AI-powered testing tools, frameworks, and resources for QA engineers, covering test generation, self-healing automation, MCP-based testing, and LLM-as-judge evaluation.
 - [Awesome Cucumber](https://github.com/virajkulkarni14/awesome-cucumber) - A (relatively-newer) curated list of awesome Cucumber and Gherkin-related resources.
 - [Awesome JMeter](https://github.com/aliesbelik/awesome-jmeter) - A curated collection of resources around Apache JMeter.
@@ -229,7 +230,6 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ## QA and Testing Road Map
 - [How to start QA and Testing career](https://github.com/fityanos/Quality-Assurance-Road-Map) - A wide and rich list of strategies, topics, and skills that you need to start a career in software testing and automation.
 - [QALadder](https://qaladder.org) - A free, sequenced roadmap from manual QA to SDET, with a 150-question interview bank, browser-based practice labs, and QA tools.
-- [QAPractices](https://qapractices.com/) - Curated QA resource hub with test cases, checklists, templates and guides for API, web, mobile, security, accessibility and performance testing.
 
 ## Others
 - [Testers Rage Playlist](https://play.spotify.com/user/sanchezni/playlist/5yzT0HrymwEeO8ckqgkPiW) - A collaborative playlist from testers for when the red mist descends.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 ## QA and Testing Road Map
 - [How to start QA and Testing career](https://github.com/fityanos/Quality-Assurance-Road-Map) - A wide and rich list of strategies, topics, and skills that you need to start a career in software testing and automation.
 - [QALadder](https://qaladder.org) - A free, sequenced roadmap from manual QA to SDET, with a 150-question interview bank, browser-based practice labs, and QA tools.
+- [QAPractices](https://qapractices.com/) - Curated QA resource hub with test cases, checklists, templates and guides for API, web, mobile, security, accessibility and performance testing.
 
 ## Others
 - [Testers Rage Playlist](https://play.spotify.com/user/sanchezni/playlist/5yzT0HrymwEeO8ckqgkPiW) - A collaborative playlist from testers for when the red mist descends.


### PR DESCRIPTION
I came across QAPractices while looking for free QA checklists and test case templates. It's a curated resource hub covering API, web, mobile, security, accessibility and performance testing with practical, free content.

I thought it would fit well in the QA and Testing Road Map section as a reference for testers who want ready-to-use templates and guides alongside career roadmaps.

Hope this helps the list.