### PR TITLE
Add False Green to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Testers Rage Playlist](https://play.spotify.com/user/sanchezni/playlist/5yzT0HrymwEeO8ckqgkPiW) - A collaborative playlist from testers for when the red mist descends.
 - [Software Testing Conferences](http://testingconferences.org/) - A list of software testing conferences and workshops.
 - [Software Testing Interview Tool](https://github.com/TheJambo/ToDoInterviewTest) - A very buggy To Do List to facilitate face to face interviews.
+- [False Green](https://github.com/massimiliano1991/false-green) - Six real incidents where an automated check reported success while measuring nothing, each with the code that caused it, what it cost and the fix.
 
 ## Contributing
 See the *Awesome Testing* [contribution guide](CONTRIBUTING.md) for details on how to contribute.


### PR DESCRIPTION
Adds one link under **Others**.

**[False Green](https://github.com/massimiliano1991/false-green)** — six real incidents where an automated check reported success while measuring nothing. For each: the code that caused it, what was actually true, the number it cost, and the fix.

Disclosure up front: **I wrote it, and it currently has 0 stars.** It is a case-study document, CC0, no product and nothing to sell.

Why I think it fits this list rather than another one:

- The Foreword scopes the list to testing *after the code is written — no unit tests, no static analysis*. Every incident here is exactly that: checks running in CI or in a live monitoring loop, not test suites.
- The failure mode is one this list's readers meet and mostly cannot name: not a check that *fails*, a check that returns **green while measuring nothing**. A crashing check gets fixed the same day; a silently-green one survives for months and decisions get stacked on top of it. The six are one bug in six shapes — *the check and the thing being checked share a failure mode*.
- Concrete rather than essayistic. Examples: a measurement organ that caught a network error and wrote `0.00 on 0 positions` over a true `-47.10 on 37`; a guard written as `a["perimeter"] != b["perimeter"]` where `perimeter` is a hand-typed module constant, so it could never fire and for 26 cycles it didn't; a paginated API that silently returns 2 rows of 14 with `retCode 0`, because *smaller* is the direction nobody validates.
- §4 is about CI specifically — a verification workflow whose honest outcome has three values while a run carries two, and what happens to your attention when the third gets merged into red (you learn to ignore red) or into green (you have an off switch with a green light on it).

If **Others** is the wrong home, or the description should be shorter, say so and I will change it — and if it is simply not a fit for the list, closing this is a perfectly good answer and I would rather have that than silence.

One thing I owe you, since it is in the repo anyway: I measured this repository's response rate to outside pull requests before opening this one — 94% of pull requests from non-collaborators here get a human reply, median 10.6h, on a sample of 31. That is the highest of the six curated lists I looked at, and it is why I brought it here rather than somewhere with more stars. The numbers, including the one with 13k stars that has answered 0 of 57 strangers, are in [delivery.md](https://github.com/massimiliano1991/false-green/blob/main/delivery.md).
