### PR TITLE
Add QAIA to AI &amp; LLM Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Evaliphy](https://github.com/evaliphy/evaliphy) - Test your AI system end-to-end with Evaliphy. It uses a Playwright-style testing approach and generates HTML reports.
 - [QASkills.sh](https://qaskills.sh) - Open registry of 400+ QA and testing skills (Playwright, API, LLM evaluation, accessibility, performance) that AI coding agents install and follow via the qaskills CLI. Works with Claude Code, Cursor, and 30+ other agents.
 - [nika](https://github.com/supernovae-st/nika) - Workflow engine for AI with testing built in: `nika test` pins a workflow's offline behavior as a golden snapshot (deterministic mock provider, zero keys) and replays it in CI; every run also leaves a hash-chained trace for post-hoc verification.
+- [QAIA](https://github.com/QAIA-Project/QAIA) - Claude Code plugins that take a user story to a Gherkin test book with stable scenario IDs and a coverage matrix, then to native Playwright tests. Ambiguous acceptance criteria are surfaced as named open questions instead of being silently resolved.
 
 ### Service Virtualization
 - [Beeceptor](https://beeceptor.com/) - Easy to use no-code mock servers for service virtualization. Rest, SOAP, GraphQL supported. Create an API mock server from OpenAPI Specification or Postman collection.


### PR DESCRIPTION
One suggestion, one PR, appended to `AI & LLM Testing`.

[QAIA](https://github.com/QAIA-Project/QAIA) (MIT) is a set of Claude Code plugins that take a user story to a Gherkin test book — stable scenario IDs, an acceptance-criterion coverage matrix — and then to native Playwright tests.

The part that is not another generator: **when an acceptance criterion is ambiguous, it does not pick.** On the worked example, 11 of 38 generated scenarios carry a named open question with the trade-off of both answers written out, waiting on a human. Silently choosing an interpretation is how a suite ends up looking complete while encoding a guess exactly at the boundary where the defects are.

**Honest state:** pre-alpha, no human pilot has run it end to end, and the project publishes its own unfavourable results — a 13-persona review scored it 2.4/5 and an architecture review 5.0/10, both self-administered agent panels rather than outside reviewers, and it says so in the repository. Declining on maturity grounds is a fair call; I would rather state this than have it discovered later.

Guidelines checked: searched the list for duplicates, individual PR for a single suggestion, description short and ending with a period, spelling and trailing whitespace checked, contribution released under CC0 per the repository licence.
