### PR TITLE
Remove duplicate Chaos Engineering book entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ Finally, I'm sure everyone who reads this list has one thing they want to add. P
 - [Thinking, Fast and Slow](https://amzn.to/2vcjasX) - About how we make decisions and how to run experiments (experiments == tests).
 - [Chaos Engineering: Crash test your applications](https://www.manning.com/books/chaos-engineering) - A book on how to design and execute controlled software failure experiments.
 - [Testing JavaScript Applications](https://www.manning.com/books/testing-javascript-applications) - A book about JavaScript testing tools and techniques for developers.
-- [Chaos Engineering](https://www.manning.com/books/chaos-engineering) - A book that teaches you to design and execute controlled experiments that uncover hidden problems.
 - [The Art of Unit Testing, Third Edition](https://www.manning.com/books/the-art-of-unit-testing-third-edition) - A book that guides you step by step from your first simple unit tests to building complete test sets that are maintainable, readable, and trustworthy.
 - [Testing Web APIs](https://www.manning.com/books/testing-web-apis) - Guarantee the quality and consistency of your web APIs by implementing an automated testing process.
 - [Effective Software Testing](https://www.manning.com/books/effective-software-testing) - A hands-on guide for developers on how to create high quality tests in a systematic and effective way.


### PR DESCRIPTION
## What changed
Removes the duplicate "Chaos Engineering" book entry from the Books section.

## Why
The same Manning book (https://www.manning.com/books/chaos-engineering) was listed twice in the Books section, three lines apart. The first entry ("Chaos Engineering: Crash test your applications") is kept; the second, more generic entry is removed. Self-found gap from a review of the list.

## How to verify
```sh
git fetch https://github.com/olitreadwell/awesome-testing.git fix/remove-duplicate-chaos-engineering-book
git checkout FETCH_HEAD
```
Docs-only change (one line removed). The remaining Chaos Engineering link resolves to HTTP 200, so the repo's dead-link checker CI is unaffected.